### PR TITLE
Add a Markdown version of the targets file.

### DIFF
--- a/target_information/targets.md
+++ b/target_information/targets.md
@@ -1,0 +1,47 @@
+# SBOM Plugfest 2024 Targets
+
+As part of SBOM Plugfest 2024 we asked the SBOM community to contribute SBOMs
+that they generated based on specified software targets. See Table 1 for
+details about the nine specified targets as representative samples of various
+programming languages and processes.
+
+At the end of the Plugfest research project, we asked Plugfest participants to
+approve making their SBOM submissions public. Those SBOMs approved for public
+release are now available for further research on the SEI’s
+[GitHub site][github].
+
+## Table 1: Software Targets
+
+| Software         | Version (GitHub)                    | Language               | For More Information (GitHub) | What does the project do? |
+|:-----------------|:------------------------------------|:-----------------------|:------------------------------|:--------------------------|
+| NodeJS-goof      | [Commit d240896 2023][c1]           | JavaScript             | [Snyk Labs][i1]               | A vulnerable Node.js demo application based on the Dreamers Lab tutorial |
+| HTTPie           | [Commit f4cf43e July 2024][c2]      | Python                 | [HTTPie cli][i2]              |  HTTPie for terminal |
+| MineColonies     | [Commit 7c184da·Oct 2024][c3]       | Java                   | [minecolonies][i3]            | An interactive building mod that allows you to create a town within Minecraft |
+| OpenCV           | [Commit 3919f33 17 Oct, 2024][c4]   | C++                    | [OpenCV][i4]                  | An Open-Source Computer Vision library |
+| Gin              | [Commit: f05f966 Sept 2024][c5]     | Go                     | [Gin-Gonic][i5]               | An HTTP web framework written in Go (Golang) |
+| Hexyl            | [Commit 427a552 Sept 2024][c6]      | Rust                   | [sharkdp][i6]                 | A command-line hex viewer |
+| Dependency Track | [4.12.1 - 25 Oct, 2024][c7]         | OCI - Java<sup>*</sup> | [Dependency-Track][i7]        | An intelligent Component Analysis platform that allows organizations to identify and reduce risk in the software supply chain and leverages SBOMs to provide capabilities that traditional Software Composition Analysis (SCA) solutions cannot achieve |
+| PHPMailer        | [Commit 182f7b9 · 15 Oct, 2024][c8] | PHP                    | [PHPMailer][i8]               | The classic email-sending library for PHP that is a full-featured email creation and transfer class for PHP |
+| jq               | [Commit 96e8d89·20 Nov, 2024][c9]   | C                      | [jqlang/jq][i9]               | A lightweight and flexible command-line JSON parser |
+
+<sup>*</sup>: OCI stands for Oracle Cloud Infrastructure.
+
+[github]: https://github.com/cmu-sei/sbom-plugfest-2024
+[c1]: https://github.com/snyk-labs/nodejs-goof/commit/d240896711e31c540fc1cab79ae2e4cf63f00b1a
+[c2]: https://github.com/httpie/cli/commit/f4cf43ecdd6c5c52b5c4ba91086d5c6ccfebcd6d
+[c3]: https://github.com/ldtteam/minecolonies/commit/7c184da03403649da9d2aec2194440f86c3a3c66
+[c4]: https://github.com/opencv/opencv/commit/3919f33e21fd0783f67901ad3429101f9b39c798
+[c5]: https://github.com/gin-gonic/gin/commit/f05f966a0824b1d302ee556183e2579c91954266
+[c6]: https://github.com/sharkdp/hexyl/commit/427a5524e19cf951fe41c2da8b940ade3ec39848
+[c7]: https://github.com/DependencyTrack/dependency-track/releases/tag/4.12.1
+[c8]: https://github.com/PHPMailer/PHPMailer/commit/182f7b9
+[c9]: https://github.com/jqlang/jq/commit/96e8d893c10ed2f7656ccb8cfa39a9a291663a7e
+[i1]: https://github.com/snyk-labs/nodejs-goof
+[i2]: https://github.com/httpie/cli
+[i3]: https://github.com/ldtteam/minecolonies
+[i4]: https://github.com/opencv/opencv
+[i5]: https://github.com/gin-gonic/gin
+[i6]: https://github.com/sharkdp/hexyl
+[i7]: https://github.com/DependencyTrack/dependency-track/releases/tag/4.12.1
+[i8]: https://github.com/PHPMailer/PHPMailer
+[i9]: https://github.com/jqlang/jq


### PR DESCRIPTION
This adds a plaintext (Markdown format) version of the targets file to make it easier for visitors to this repo to check was open source software was made available to participants in the Plugfest event.